### PR TITLE
Upgraded due to the restriction of http on latest Netscaler version

### DIFF
--- a/lib/NS-UpdateService.ps1
+++ b/lib/NS-UpdateService.ps1
@@ -7,7 +7,7 @@ if ($psver -eq "1" -or $psver -eq "2") {
 $NSAddress = $OctopusParameters['HostName']
 $NSUserName = $OctopusParameters['Username']
 $NSPassword = $OctopusParameters['Password']
-$NSProtocol="http"
+$NSProtocol=$OctopusParameters['Protocol']
 $Action = $OctopusParameters['EnableOrDisable']
 $ServiceName = $OctopusParameters['ServiceName']
 $GracefulShutdown = $OctopusParameters['Graceful']
@@ -50,11 +50,6 @@ function Connect-NSAppliance {
     Write-Verbose "$($MyInvocation.MyCommand): Enter"
 
     if ($PSCmdlet.ParameterSetName -eq 'Address') {
-        Write-Verbose "Validating IP Address"
-        $IPAddressObj = New-Object -TypeName System.Net.IPAddress -ArgumentList 0
-        if (-not [System.Net.IPAddress]::TryParse($NSAddress,[ref]$IPAddressObj)) {
-            throw "'$NSAddress' is an invalid IP address"
-        }
         $nsEndpoint = $NSAddress
     } elseif ($PSCmdlet.ParameterSetName -eq 'Name') {
         $nsEndpoint = $NSName

--- a/octopusdeploy/netscaler-adc-enable-disable-service.json
+++ b/octopusdeploy/netscaler-adc-enable-disable-service.json
@@ -55,6 +55,15 @@
         "Octopus.ControlType": "SingleLineText"
       }
     },
+	{
+      "Name": "Protocol",
+      "Label": "NetScaler ADC Protocol",
+      "HelpText": "http or https",
+      "DefaultValue": "http",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
     {
       "Name": "Graceful",
       "Label": "Graceful shutdown",


### PR DESCRIPTION
* On latest version of Netscaler, you have to use secure layer (https).
* Protocol added to let user choose http or https while connecting.
* "IP Address" validation removed due to SSL certificate error on use of domain name here.